### PR TITLE
fix: stream pipe all args

### DIFF
--- a/src/stream.js
+++ b/src/stream.js
@@ -101,8 +101,16 @@ export default class Stream {
    * @see http://nodejs.org/api/stream.html#stream_readable_pipe_destination_options
    */
   pipe(destination) {
-    this.on('data', function(data) {
-      destination.push(data);
+    this.on('data', function() {
+      if (arguments.length === 1) {
+        destination.push(arguments[0]);
+      } else {
+        const args = Array.prototype.slice.call(arguments, 0);
+
+        args.forEach(function(arg) {
+          destination.push(arg);
+        });
+      }
     });
   }
 }

--- a/test/stream.test.js
+++ b/test/stream.test.js
@@ -15,14 +15,17 @@ QUnit.module('stream', {
 QUnit.test('trigger calls listeners', function(assert) {
   const args = [];
 
-  this.stream.on('test', function(data) {
-    args.push(data);
+  this.stream.on('test', function(...data) {
+    data.forEach((d) => {
+      args.push(d);
+    });
   });
 
   this.stream.trigger('test', 1);
   this.stream.trigger('test', 2);
+  this.stream.trigger('test', 3, 4);
 
-  assert.deepEqual(args, [1, 2]);
+  assert.deepEqual(args, [1, 2, 3, 4]);
 });
 
 QUnit.test('callbacks can remove themselves', function(assert) {
@@ -48,4 +51,32 @@ QUnit.test('callbacks can remove themselves', function(assert) {
   assert.deepEqual(args1, [1, 2], 'first callback ran all times');
   assert.deepEqual(args2, [1], 'second callback removed after first run');
   assert.deepEqual(args3, [1, 2], 'third callback ran all times');
+});
+
+QUnit.test('can pipe', function(assert) {
+  const pipeData = [];
+  const stream2 = new Stream();
+
+  stream2.push = function(data) {
+    assert.equal(this, stream2, 'context is the same');
+    pipeData.push(data);
+  };
+
+  this.stream
+    .pipe(stream2);
+
+  this.stream.trigger('data', 1, 2, 3, 4, 5);
+  this.stream.trigger('data', 6);
+
+  assert.deepEqual(pipeData, [1, 2, 3, 4, 5, 6], 'data piped to stream2');
+
+  stream2.dispose();
+});
+
+QUnit.test('off no listener', function(assert) {
+  assert.strictEqual(this.stream.off('nope'), false, 'returns false when no listener is removed');
+});
+
+QUnit.test('trigger no listener', function(assert) {
+  assert.strictEqual(this.stream.trigger('nope'), undefined, 'returns undefined for trigger with no listeners');
 });


### PR DESCRIPTION
Noticed that our pipe function only passes the first argument, and not all arguments from a trigger. It is unknown if this actually effects us. I also added more unit tests so that we can have 100% coverage.