### PR TITLE
Add media-types module with simpleTypeFromSourceType function

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,12 @@
 
 # @videojs/vhs-utils
 
-Objects and functions shared throughtout @videojs/http-streaming code
+vhs-utils serves two purposes:
+
+1. It extracts objects and functions shared throughout @videojs/http-streaming code to save on package size. See [the original @videojs/http-streaming PR](https://github.com/videojs/http-streaming/pull/637) for details.
+2. It exports functions useful to plugin authors to mimic some logic VHS uses internally.
+
+Note that for the case of 2, although the functions are exported, they may change at any time, although appropriate semantic versioning of this module will be maintained.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -13,9 +13,7 @@
 vhs-utils serves two purposes:
 
 1. It extracts objects and functions shared throughout @videojs/http-streaming code to save on package size. See [the original @videojs/http-streaming PR](https://github.com/videojs/http-streaming/pull/637) for details.
-2. It exports functions useful to plugin authors to mimic some logic VHS uses internally.
-
-Note that for the case of 2, although the functions are exported, they may change at any time, although appropriate semantic versioning of this module will be maintained.
+2. It exports generic functions from VHS that may be useful to plugin authors.
 
 ## Installation
 

--- a/src/media-types.js
+++ b/src/media-types.js
@@ -1,0 +1,36 @@
+const mpegurlRE = /^(audio|video|application)\/(x-|vnd\.apple\.)?mpegurl/i;
+const dashRE = /^application\/dash\+xml/i;
+
+/**
+ * Returns a string that describes the type of source based on a video source object's
+ * media type.
+ *
+ * @see {@link https://dev.w3.org/html5/pf-summary/video.html#dom-source-type|Source Type}
+ *
+ * @param {string} type
+ *        Video source object media type
+ * @return {('hls'|'dash'|'vhs-json'|null)}
+ *         VHS source type string
+ */
+export const simpleTypeFromSourceType = (type) => {
+  if (mpegurlRE.test(type)) {
+    return 'hls';
+  }
+
+  if (dashRE.test(type)) {
+    return 'dash';
+  }
+
+  // Denotes the special case of a pre-parsed manifest object passed in instead of the
+  // traditional source URL.
+  //
+  // See https://en.wikipedia.org/wiki/Media_type for details on specifying media types.
+  //
+  // In this case, vnd is for vendor, VHS is for this project, and the +json suffix
+  // identifies the structure of the media type.
+  if (type === 'application/vnd.vhs+json') {
+    return 'vhs-json';
+  }
+
+  return null;
+};

--- a/src/media-types.js
+++ b/src/media-types.js
@@ -1,5 +1,5 @@
-const mpegurlRE = /^(audio|video|application)\/(x-|vnd\.apple\.)?mpegurl/i;
-const dashRE = /^application\/dash\+xml/i;
+const MPEGURL_REGEX = /^(audio|video|application)\/(x-|vnd\.apple\.)?mpegurl/i;
+const DASH_REGEX = /^application\/dash\+xml/i;
 
 /**
  * Returns a string that describes the type of source based on a video source object's
@@ -13,16 +13,16 @@ const dashRE = /^application\/dash\+xml/i;
  *         VHS source type string
  */
 export const simpleTypeFromSourceType = (type) => {
-  if (mpegurlRE.test(type)) {
+  if (MPEGURL_REGEX.test(type)) {
     return 'hls';
   }
 
-  if (dashRE.test(type)) {
+  if (DASH_REGEX.test(type)) {
     return 'dash';
   }
 
-  // Denotes the special case of a pre-parsed manifest object passed in instead of the
-  // traditional source URL.
+  // Denotes the special case of a manifest object passed to http-streaming instead of a
+  // source URL.
   //
   // See https://en.wikipedia.org/wiki/Media_type for details on specifying media types.
   //

--- a/test/media-types.test.js
+++ b/test/media-types.test.js
@@ -1,0 +1,41 @@
+import QUnit from 'qunit';
+import { simpleTypeFromSourceType } from '../src/media-types';
+
+QUnit.module('simpleTypeFromSourceType');
+
+QUnit.test('simpleTypeFromSourceType converts HLS mime types to hls', function(assert) {
+  assert.equal(
+    simpleTypeFromSourceType('aPplicatiOn/x-MPegUrl'),
+    'hls',
+    'supports application/x-mpegurl'
+  );
+  assert.equal(
+    simpleTypeFromSourceType('aPplicatiOn/VnD.aPPle.MpEgUrL'),
+    'hls',
+    'supports application/vnd.apple.mpegurl'
+  );
+});
+
+QUnit.test('simpleTypeFromSourceType converts DASH mime type to dash', function(assert) {
+  assert.equal(
+    simpleTypeFromSourceType('aPplication/dAsh+xMl'),
+    'dash',
+    'supports application/dash+xml'
+  );
+});
+
+QUnit.test(
+  'simpleTypeFromSourceType does not convert non HLS/DASH mime types',
+  function(assert) {
+    assert.notOk(simpleTypeFromSourceType('video/mp4'), 'does not support video/mp4');
+    assert.notOk(simpleTypeFromSourceType('video/x-flv'), 'does not support video/x-flv');
+  }
+);
+
+QUnit.test('simpleTypeFromSourceType converts VHS media type to vhs-json', function(assert) {
+  assert.equal(
+    simpleTypeFromSourceType('application/vnd.vhs+json'),
+    'vhs-json',
+    'supports application/vnd.vhs+json'
+  );
+});


### PR DESCRIPTION
Note that with this PR, the scope of this module changes to encompass more use-cases. See the README notes for details.

Also note that this includes functionality for https://github.com/videojs/http-streaming/pull/649, and helps to break that PR up into fewer code changes per PR. If this gets merged, those functions can be stripped from @videojs/http-streaming and simply reference this module's functions.

So long as the scope change of this module is acceptable, more PRs will be added soon with additional extracted functions from VHS.

Code derived from https://github.com/videojs/http-streaming/blob/master/src/videojs-http-streaming.js#L85