### PR TITLE
fix: Allow VP9 and AV1 codecs through in VHS

### DIFF
--- a/src/codecs.js
+++ b/src/codecs.js
@@ -80,7 +80,7 @@ export const parseCodecs = function(codecs = '') {
   result.codecCount = result.codecCount || 2;
 
   // parse the video codec
-  const parsed = (/(^|\s|,)+(avc[13])([^ ,]*)/i).exec(codecs);
+  const parsed = (/(^|\s|,)+(avc[13]|vp09|av01)([^ ,]*)/i).exec(codecs);
 
   if (parsed) {
     result.videoCodec = parsed[2];


### PR DESCRIPTION
Firefox doesn't seem to care about the specified type, but
Chrome doesn't like the empty codecs specifier that comes
from not passing through codec id through.

This is a port of https://github.com/videojs/http-streaming/pull/617 against vhs-utils. When approved I'll merge it manually locally so that @brion gets credit for the change.