### PR TITLE
refactor(BREAKING): refactor codec handling to split muxer/browser support

### DIFF
--- a/src/codecs.js
+++ b/src/codecs.js
@@ -2,17 +2,17 @@ import window from 'global/window';
 
 const regexs = {
   // to determine mime types
-  mp4: RegExp('^(av0?1|avc0?[1234]|vp0?9|flac|opus|mp3|mp4a|mp4v)'),
-  webm: RegExp('^(vp0?[89]|av0?1|opus|vorbis)'),
-  ogg: RegExp('^(vp0?[89]|theora|flac|opus|vorbis)'),
+  mp4: /^(av0?1|avc0?[1234]|vp0?9|flac|opus|mp3|mp4a|mp4v)/,
+  webm: /^(vp0?[89]|av0?1|opus|vorbis)/,
+  ogg: /^(vp0?[89]|theora|flac|opus|vorbis)/,
 
   // to determine if a codec is audio or video
-  video: RegExp('^(av0?1|avc0?[1234]|vp0?[89]|hvc1|hev1|theora|mp4v)'),
-  audio: RegExp('^(mp4a|flac|vorbis|opus|ac-[34]|ec-3|alac|mp3)'),
+  video: /^(av0?1|avc0?[1234]|vp0?[89]|hvc1|hev1|theora|mp4v)/,
+  audio: /^(mp4a|flac|vorbis|opus|ac-[34]|ec-3|alac|mp3)/,
 
   // mux.js support regex
-  muxerVideo: RegExp('^(avc0?1)'),
-  muxerAudio: RegExp('^(mp4a)')
+  muxerVideo: /^(avc0?1)/,
+  muxerAudio: /^(mp4a)/
 };
 
 /**
@@ -102,6 +102,7 @@ export const parseCodecs = function(codecString = '') {
         return;
       }
 
+      // maintain codec case
       const type = codec.substring(0, match[1].length);
       const details = codec.replace(type, '');
 

--- a/src/codecs.js
+++ b/src/codecs.js
@@ -188,12 +188,10 @@ export const browserSupportsCodec = (codecString = '') => window.MediaSource &&
   window.MediaSource.isTypeSupported &&
   window.MediaSource.isTypeSupported(getMimeForCodec(codecString)) || false;
 
-export const muxerSupportsCodec = (codecString = '') => codecString.toLowerCase().split(',').every(function(codec) {
+export const muxerSupportsCodec = (codecString = '') => codecString.toLowerCase().split(',').every((codec) => {
   codec = codec.trim();
 
-  if (regexs.muxerVideo.test(codec) || regexs.muxerAudio.test(codec)) {
-    return true;
-  }
+  return regexs.muxerVideo.test(codec) || regexs.muxerAudio.test(codec);
 });
 
 export const DEFAULT_AUDIO_CODEC = 'mp4a.40.2';

--- a/src/codecs.js
+++ b/src/codecs.js
@@ -88,7 +88,7 @@ export const parseCodecs = function(codecString = '') {
   const result = {};
 
   codecs.forEach(function(codec) {
-    codec = translateLegacyCodec(codec.trim());
+    codec = codec.trim();
 
     const videoCodecMatch = videoCodecRegex.exec(codec);
     const audioCodecMatch = audioCodecRegex.exec(codec);
@@ -147,13 +147,6 @@ export const codecsFromDefault = (master, audioGroupId) => {
 
 export const isVideoCodec = (codec = '') => videoCodecRegex.test(codec.trim().toLowerCase());
 export const isAudioCodec = (codec = '') => audioCodecRegex.test(codec.trim().toLowerCase());
-export const muxerSupportsCodec = (codecString = '') => codecString.split(',').every(function(codec) {
-  codec = codec.trim().toLowerCase();
-
-  if (muxerVideoRegex.test(codec) || muxerAudioRegex.test(codec)) {
-    return true;
-  }
-});
 
 export const getMimeForCodec = (codecString) => {
   if (!codecString || typeof codecString !== 'string') {
@@ -192,9 +185,14 @@ export const getMimeForCodec = (codecString) => {
 export const browserSupportsCodec = (codecString = '') => window.MediaSource &&
   window.MediaSource.isTypeSupported &&
   window.MediaSource.isTypeSupported(getMimeForCodec(codecString)) || false;
-export const isCodecSupported = (codecString) =>
-  muxerSupportsCodec(codecString) && browserSupportsCodec(codecString);
+
+export const muxerSupportsCodec = (codecString = '') => codecString.split(',').every(function(codec) {
+  codec = codec.trim().toLowerCase();
+
+  if (muxerVideoRegex.test(codec) || muxerAudioRegex.test(codec)) {
+    return true;
+  }
+});
 
 export const DEFAULT_AUDIO_CODEC = 'mp4a.40.2';
 export const DEFAULT_VIDEO_CODEC = 'avc1.4d400d';
-

--- a/src/codecs.js
+++ b/src/codecs.js
@@ -1,6 +1,10 @@
 import window from 'global/window';
-const videoSupportRegex = RegExp('^(avc[13]|vp09|av01)');
-const audioSupportRegex = RegExp('^(mp4a)');
+
+const videoCodecRegex = RegExp('^(av1|avc0?[1234]|vp0?[89]|hvc1|hev1|theora|mp4v)');
+const audioCodecRegex = RegExp('^(mp4a|flac|vorbis|opus|ac-[34]|ec-3|alac)');
+
+const muxerVideoRegex = RegExp('^(avc0?1)');
+const muxerAudioRegex = RegExp('^(mp4a)');
 
 /**
  * Replace the old apple-style `avc1.<dd>.<dd>` codec string with the standard
@@ -82,8 +86,8 @@ export const parseCodecs = function(codecString = '') {
   codecs.forEach(function(codec) {
     codec = codec.trim();
 
-    const videoCodecMatch = videoSupportRegex.exec(codec);
-    const audioCodecMatch = audioSupportRegex.exec(codec);
+    const videoCodecMatch = videoCodecRegex.exec(codec);
+    const audioCodecMatch = audioCodecRegex.exec(codec);
 
     if (videoCodecMatch && videoCodecMatch.length > 1) {
       result.videoCodec = videoCodecMatch[1];
@@ -135,10 +139,12 @@ export const codecsFromDefault = (master, audioGroupId) => {
   return null;
 };
 
-export const isVideoCodec = (codec) => videoSupportRegex.test(codec.trim().toLowerCase());
-export const isAudioCodec = (codec) => audioSupportRegex.test(codec.trim().toLowerCase());
+export const isVideoCodec = (codec) => videoCodecRegex.test(codec.trim().toLowerCase());
+export const isAudioCodec = (codec) => audioCodecRegex.test(codec.trim().toLowerCase());
 export const muxerSupportsCodec = (codecString) => codecString.split(',').every(function(codec) {
-  if (isAudioCodec(codec) || isVideoCodec(codec)) {
+  codec = codec.trim().toLowerCase();
+
+  if (muxerVideoRegex.test(codec) || muxerAudioRegex.test(codec)) {
     return true;
   }
 });

--- a/test/codecs.test.js
+++ b/test/codecs.test.js
@@ -9,7 +9,6 @@ import {
   isAudioCodec,
   muxerSupportsCodec,
   browserSupportsCodec,
-  isCodecSupported,
   getMimeForCodec
 } from '../src/codecs';
 
@@ -357,29 +356,6 @@ QUnit.test('works as expected', function(assert) {
 
   window.MediaSource = {isTypeSupported: null};
   assert.notOk(browserSupportsCodec('test'), 'no isTypeSupported, browser does not support codec');
-});
-
-QUnit.module('isCodecSupported', {
-  beforeEach() {
-    this.oldMediaSource = window.MediaSource;
-  },
-  afterEach() {
-    window.MediaSource = this.oldMediaSource;
-  }
-});
-
-QUnit.test('works as expected', function(assert) {
-  window.MediaSource = {isTypeSupported: () => true};
-  assert.ok(isCodecSupported(supportedMuxerCodecs[0]), 'browser true, muxer true, supported');
-
-  window.MediaSource = {isTypeSupported: () => false};
-  assert.notOk(isCodecSupported(supportedMuxerCodecs[0]), 'browser false, muxer true, not supported');
-
-  window.MediaSource = {isTypeSupported: () => true};
-  assert.notOk(isCodecSupported(unsupportedMuxerCodecs[0]), 'browser true, muxer false, not supported');
-
-  window.MediaSource = {isTypeSupported: () => false};
-  assert.notOk(isCodecSupported(unsupportedMuxerCodecs[0]), 'browser false, muxer false, not supported');
 });
 
 QUnit.module('getMimeForCodec');

--- a/test/codecs.test.js
+++ b/test/codecs.test.js
@@ -310,7 +310,7 @@ QUnit.test('works as expected', function(assert) {
   });
 });
 
-QUnit.module('muxerSupportCodec');
+QUnit.module('muxerSupportsCodec');
 QUnit.test('works as expected', function(assert) {
   const validMuxerCodecs = [];
   const invalidMuxerCodecs = [];
@@ -326,12 +326,12 @@ QUnit.test('works as expected', function(assert) {
   supportedMuxerCodecs.forEach(function(codec, i) {
     validMuxerCodecs.push(codec);
 
-    supportedMuxerCodecs.forEach(function(subcodec, z) {
+    supportedMuxerCodecs.forEach(function(_codec, z) {
       if (z === i) {
         return;
       }
-      validMuxerCodecs.push(`${codec}, ${subcodec}`);
-      validMuxerCodecs.push(`${codec},${subcodec}`);
+      validMuxerCodecs.push(`${codec}, ${_codec}`);
+      validMuxerCodecs.push(`${codec},${_codec}`);
     });
   });
 

--- a/test/codecs.test.js
+++ b/test/codecs.test.js
@@ -14,9 +14,7 @@ import {
 
 const supportedMuxerCodecs = [
   'mp4a',
-  'avc1',
-  'vp09',
-  'av01'
+  'avc1'
 ];
 
 const unsupportedMuxerCodecs = [
@@ -264,13 +262,27 @@ QUnit.test('returns audio profile for default in audio group', function(assert) 
 
 QUnit.module('isVideoCodec');
 QUnit.test('works as expected', function(assert) {
-  ['avc1', 'vp09', 'av01'].forEach(function(codec) {
+  [
+    'av1',
+    'avc01',
+    'avc1',
+    'avc02',
+    'avc2',
+    'vp09',
+    'vp9',
+    'vp8',
+    'vp08',
+    'hvc1',
+    'hev1',
+    'theora',
+    'mp4v'
+  ].forEach(function(codec) {
     assert.ok(isVideoCodec(codec), `"${codec}" is seen as a video codec`);
     assert.ok(isVideoCodec(` ${codec} `), `" ${codec} " is seen as video codec`);
     assert.ok(isVideoCodec(codec.toUpperCase()), `"${codec.toUpperCase()}" is seen as video codec`);
   });
 
-  ['invalid', 'foo', 'avc', 'vp9', 'vp08', 'hvc1'].forEach(function(codec) {
+  ['invalid', 'foo', 'mp4a', 'opus', 'vorbis'].forEach(function(codec) {
     assert.notOk(isVideoCodec(codec), `${codec} is not a video codec`);
   });
 
@@ -278,13 +290,22 @@ QUnit.test('works as expected', function(assert) {
 
 QUnit.module('isAudioCodec');
 QUnit.test('works as expected', function(assert) {
-  ['mp4a'].forEach(function(codec) {
+  [
+    'mp4a',
+    'flac',
+    'vorbis',
+    'opus',
+    'ac-3',
+    'ac-4',
+    'ec-3',
+    'alac'
+  ].forEach(function(codec) {
     assert.ok(isAudioCodec(codec), `"${codec}" is seen as an audio codec`);
     assert.ok(isAudioCodec(` ${codec} `), `" ${codec} " is seen as an audio codec`);
     assert.ok(isAudioCodec(codec.toUpperCase()), `"${codec.toUpperCase()}" is seen as an audio codec`);
   });
 
-  ['invalid', 'ac-3', 'ec-3', 'foo', 'mp3'].forEach(function(codec) {
+  ['invalid', 'foo', 'bar', 'avc1', 'av1'].forEach(function(codec) {
     assert.notOk(isAudioCodec(codec), `${codec} is not an audio codec`);
   });
 });

--- a/test/codecs.test.js
+++ b/test/codecs.test.js
@@ -149,6 +149,17 @@ QUnit.test('parses video and audio codec string', function(assert) {
   );
 });
 
+QUnit.test('parses video and audio codec with mixed case', function(assert) {
+  assert.deepEqual(
+    parseCodecs('AvC1.42001E, Mp4A.40.E'),
+    {
+      video: {type: 'AvC1', details: '.42001E'},
+      audio: {type: 'Mp4A', details: '.40.E'}
+    },
+    'parsed video and audio codec string'
+  );
+});
+
 QUnit.module('codecsFromDefault');
 
 QUnit.test('returns falsey when no audio group ID', function(assert) {
@@ -382,4 +393,6 @@ QUnit.test('works as expected', function(assert) {
   assert.equal(getMimeForCodec('foo'), 'video/mp4;codecs="foo"', 'mp4 is the default');
 
   assert.notOk(getMimeForCodec(), 'invalid codec returns undefined');
+
+  assert.equal(getMimeForCodec('Mp4A.40.2,AvC1.42001E'), 'video/mp4;codecs="Mp4A.40.2,AvC1.42001E"', 'case is preserved');
 });


### PR DESCRIPTION
This is breaking because `parseCodecs` is changed to support more than just `mp4a` and `audioProfileFromDefault` was changed to `codecsFromDefault` so that it can return more than just `mp4a` and it gets more than just audio

See: https://github.com/videojs/http-streaming/pull/762