### PR TITLE
fix: parse unknown codecs as audio/video

### DIFF
--- a/src/codecs.js
+++ b/src/codecs.js
@@ -119,6 +119,7 @@ export const parseCodecs = function(codecString = '') {
     }
   });
 
+  // TODO: Report that a codec could not be identified somehow
   // Set unknown codecs to either the "missing" audio or video codec.
   // If we have all unknown codecs the first one will always be
   // video and the second one will always be audio.

--- a/src/codecs.js
+++ b/src/codecs.js
@@ -91,9 +91,11 @@ export const mapLegacyAvcCodecs = function(codecString) {
 export const parseCodecs = function(codecString = '') {
   const codecs = codecString.split(',');
   const result = {};
+  const unknown = [];
 
   codecs.forEach(function(codec) {
     codec = codec.trim();
+    let codecType;
 
     ['video', 'audio'].forEach(function(name) {
       const match = regexs[name].exec(codec.toLowerCase());
@@ -101,6 +103,7 @@ export const parseCodecs = function(codecString = '') {
       if (!match || match.length <= 1) {
         return;
       }
+      codecType = name;
 
       // maintain codec case
       const type = codec.substring(0, match[1].length);
@@ -108,6 +111,19 @@ export const parseCodecs = function(codecString = '') {
 
       result[name] = {type, details};
     });
+
+    if (!codecType) {
+      unknown.push(codec);
+    }
+
+  });
+
+  unknown.forEach(function(codec) {
+    if (!result.video) {
+      result.video = {type: codec, details: ''};
+    } else if (!result.audio) {
+      result.audio = {type: codec, details: ''};
+    }
   });
 
   return result;

--- a/src/codecs.js
+++ b/src/codecs.js
@@ -112,12 +112,16 @@ export const parseCodecs = function(codecString = '') {
       result[name] = {type, details};
     });
 
+    // codec type is not audio or video
+    // try to deremine its type after all the other codecs
     if (!codecType) {
       unknown.push(codec);
     }
-
   });
 
+  // Set unknown codecs to either the "missing" audio or video codec.
+  // If we have all unknown codecs the first one will always be
+  // video and the second one will always be audio.
   unknown.forEach(function(codec) {
     if (!result.video) {
       result.video = {type: codec, details: ''};

--- a/test/codecs.test.js
+++ b/test/codecs.test.js
@@ -160,6 +160,39 @@ QUnit.test('parses video and audio codec with mixed case', function(assert) {
   );
 });
 
+QUnit.test('parses two unknown codec', function(assert) {
+  assert.deepEqual(
+    parseCodecs('fake.codec, other-fake'),
+    {
+      video: {type: 'fake.codec', details: ''},
+      audio: {type: 'other-fake', details: ''}
+    },
+    'parsed faked codecs as video/audio'
+  );
+});
+
+QUnit.test('parses on unknown video codec with a known audio', function(assert) {
+  assert.deepEqual(
+    parseCodecs('fake.codec, mp4a.40.2'),
+    {
+      video: {type: 'fake.codec', details: ''},
+      audio: {type: 'mp4a', details: '.40.2'}
+    },
+    'parsed faked video codec'
+  );
+});
+
+QUnit.test('parses on unknown audio codec with a known video', function(assert) {
+  assert.deepEqual(
+    parseCodecs('avc1.42001e, other-fake'),
+    {
+      video: {type: 'avc1', details: '.42001e'},
+      audio: {type: 'other-fake', details: ''}
+    },
+    'parsed faked audio codec'
+  );
+});
+
 QUnit.module('codecsFromDefault');
 
 QUnit.test('returns falsey when no audio group ID', function(assert) {


### PR DESCRIPTION
I noticed that we do not parse out unknown codecs, we should instead set unknown codecs to the missing codec type (video or audio).