### PR TITLE
Revert "fix: parse unknown codecs as audio or video (#15)"

### DIFF
--- a/src/codecs.js
+++ b/src/codecs.js
@@ -91,11 +91,9 @@ export const mapLegacyAvcCodecs = function(codecString) {
 export const parseCodecs = function(codecString = '') {
   const codecs = codecString.split(',');
   const result = {};
-  const unknown = [];
 
   codecs.forEach(function(codec) {
     codec = codec.trim();
-    let codecType;
 
     ['video', 'audio'].forEach(function(name) {
       const match = regexs[name].exec(codec.toLowerCase());
@@ -103,7 +101,6 @@ export const parseCodecs = function(codecString = '') {
       if (!match || match.length <= 1) {
         return;
       }
-      codecType = name;
 
       // maintain codec case
       const type = codec.substring(0, match[1].length);
@@ -111,24 +108,6 @@ export const parseCodecs = function(codecString = '') {
 
       result[name] = {type, details};
     });
-
-    // codec type is not audio or video
-    // try to deremine its type after all the other codecs
-    if (!codecType) {
-      unknown.push(codec);
-    }
-  });
-
-  // TODO: Report that a codec could not be identified somehow
-  // Set unknown codecs to either the "missing" audio or video codec.
-  // If we have all unknown codecs the first one will always be
-  // video and the second one will always be audio.
-  unknown.forEach(function(codec) {
-    if (!result.video) {
-      result.video = {type: codec, details: ''};
-    } else if (!result.audio) {
-      result.audio = {type: codec, details: ''};
-    }
   });
 
   return result;

--- a/test/codecs.test.js
+++ b/test/codecs.test.js
@@ -160,39 +160,6 @@ QUnit.test('parses video and audio codec with mixed case', function(assert) {
   );
 });
 
-QUnit.test('parses two unknown codec', function(assert) {
-  assert.deepEqual(
-    parseCodecs('fake.codec, other-fake'),
-    {
-      video: {type: 'fake.codec', details: ''},
-      audio: {type: 'other-fake', details: ''}
-    },
-    'parsed faked codecs as video/audio'
-  );
-});
-
-QUnit.test('parses on unknown video codec with a known audio', function(assert) {
-  assert.deepEqual(
-    parseCodecs('fake.codec, mp4a.40.2'),
-    {
-      video: {type: 'fake.codec', details: ''},
-      audio: {type: 'mp4a', details: '.40.2'}
-    },
-    'parsed faked video codec'
-  );
-});
-
-QUnit.test('parses on unknown audio codec with a known video', function(assert) {
-  assert.deepEqual(
-    parseCodecs('avc1.42001e, other-fake'),
-    {
-      video: {type: 'avc1', details: '.42001e'},
-      audio: {type: 'other-fake', details: ''}
-    },
-    'parsed faked audio codec'
-  );
-});
-
 QUnit.module('codecsFromDefault');
 
 QUnit.test('returns falsey when no audio group ID', function(assert) {


### PR DESCRIPTION
This reverts commit cd2c9bb32b7008501b21c1609e993f9d5554e60d.

With the recent addition of subtitle codecs, I realized that this was a bad change. We should instead mark these codecs unto an unknown property. Luckily we didn't do any releases with this code.