### PR TITLE
feat: parse unknown and text codecs

### DIFF
--- a/src/codecs.js
+++ b/src/codecs.js
@@ -98,8 +98,7 @@ export const mapLegacyAvcCodecs = function(codecString) {
  */
 export const parseCodecs = function(codecString = '') {
   const codecs = codecString.split(',');
-  const result = {};
-  const unknown = [];
+  const result = [];
 
   codecs.forEach(function(codec) {
     codec = codec.trim();
@@ -117,17 +116,13 @@ export const parseCodecs = function(codecString = '') {
       const type = codec.substring(0, match[1].length);
       const details = codec.replace(type, '');
 
-      result[name] = {type, details};
+      result.push({type, details, mediaType: name});
     });
 
     if (!codecType) {
-      unknown.push(codec);
+      result.push({type: codec, details: '', mediaType: 'unknown'});
     }
   });
-
-  if (unknown.length) {
-    result.unknown = unknown;
-  }
 
   return result;
 };

--- a/src/codecs.js
+++ b/src/codecs.js
@@ -98,7 +98,8 @@ export const mapLegacyAvcCodecs = function(codecString) {
  */
 export const parseCodecs = function(codecString = '') {
   const codecs = codecString.split(',');
-  const result = [];
+  const result = {};
+  const unknown = [];
 
   codecs.forEach(function(codec) {
     codec = codec.trim();
@@ -116,13 +117,17 @@ export const parseCodecs = function(codecString = '') {
       const type = codec.substring(0, match[1].length);
       const details = codec.replace(type, '');
 
-      result.push({type, details, mediaType: name});
+      result[name] = {type, details};
     });
 
     if (!codecType) {
-      result.push({type: codec, details: '', mediaType: 'unknown'});
+      unknown.push(codec);
     }
   });
+
+  if (unknown.length) {
+    result.unknown = unknown;
+  }
 
   return result;
 };

--- a/test/codecs.test.js
+++ b/test/codecs.test.js
@@ -125,7 +125,7 @@ QUnit.module('parseCodecs');
 QUnit.test('parses text only codec string', function(assert) {
   assert.deepEqual(
     parseCodecs('stpp.ttml.im1t'),
-    {text: {type: 'stpp.ttml.im1t', details: ''}},
+    [{mediaType: 'text', type: 'stpp.ttml.im1t', details: ''}],
     'parsed text only codec string'
   );
 });
@@ -133,7 +133,7 @@ QUnit.test('parses text only codec string', function(assert) {
 QUnit.test('parses video only codec string', function(assert) {
   assert.deepEqual(
     parseCodecs('avc1.42001e'),
-    {video: {type: 'avc1', details: '.42001e'}},
+    [{mediaType: 'video', type: 'avc1', details: '.42001e'}],
     'parsed video only codec string'
   );
 });
@@ -141,7 +141,7 @@ QUnit.test('parses video only codec string', function(assert) {
 QUnit.test('parses audio only codec string', function(assert) {
   assert.deepEqual(
     parseCodecs('mp4a.40.2'),
-    {audio: {type: 'mp4a', details: '.40.2'}},
+    [{mediaType: 'audio', type: 'mp4a', details: '.40.2'}],
     'parsed audio only codec string'
   );
 });
@@ -149,11 +149,11 @@ QUnit.test('parses audio only codec string', function(assert) {
 QUnit.test('parses video, audio, and text codec string', function(assert) {
   assert.deepEqual(
     parseCodecs('avc1.42001e, mp4a.40.2, stpp.ttml.im1t'),
-    {
-      video: {type: 'avc1', details: '.42001e'},
-      audio: {type: 'mp4a', details: '.40.2'},
-      text: {type: 'stpp.ttml.im1t', details: ''}
-    },
+    [
+      {mediaType: 'video', type: 'avc1', details: '.42001e'},
+      {mediaType: 'audio', type: 'mp4a', details: '.40.2'},
+      {mediaType: 'text', type: 'stpp.ttml.im1t', details: ''}
+    ],
     'parsed video, audio, and text codec string'
   );
 });
@@ -161,11 +161,11 @@ QUnit.test('parses video, audio, and text codec string', function(assert) {
 QUnit.test('parses video, audio, and text codec with mixed case', function(assert) {
   assert.deepEqual(
     parseCodecs('AvC1.42001E, Mp4A.40.E, stpp.TTML.im1T'),
-    {
-      video: {type: 'AvC1', details: '.42001E'},
-      audio: {type: 'Mp4A', details: '.40.E'},
-      text: {type: 'stpp.TTML.im1T', details: ''}
-    },
+    [
+      {mediaType: 'video', type: 'AvC1', details: '.42001E'},
+      {mediaType: 'audio', type: 'Mp4A', details: '.40.E'},
+      {mediaType: 'text', type: 'stpp.TTML.im1T', details: ''}
+    ],
     'parsed video, audio, and text codec string'
   );
 });
@@ -173,7 +173,10 @@ QUnit.test('parses video, audio, and text codec with mixed case', function(asser
 QUnit.test('parses two unknown codec', function(assert) {
   assert.deepEqual(
     parseCodecs('fake.codec, other-fake'),
-    {unknown: ['fake.codec', 'other-fake']},
+    [
+      {mediaType: 'unknown', type: 'fake.codec', details: ''},
+      {mediaType: 'unknown', type: 'other-fake', details: ''}
+    ],
     'parsed faked codecs as video/audio'
   );
 });
@@ -181,21 +184,21 @@ QUnit.test('parses two unknown codec', function(assert) {
 QUnit.test('parses an unknown codec with a known audio', function(assert) {
   assert.deepEqual(
     parseCodecs('fake.codec, mp4a.40.2'),
-    {
-      audio: {type: 'mp4a', details: '.40.2'},
-      unknown: ['fake.codec']
-    },
-    'parsed faked video codec'
+    [
+      {mediaType: 'unknown', type: 'fake.codec', details: ''},
+      {mediaType: 'audio', type: 'mp4a', details: '.40.2'}
+    ],
+    'parsed audio and unknwon'
   );
 });
 
 QUnit.test('parses an unknown codec with a known video', function(assert) {
   assert.deepEqual(
     parseCodecs('avc1.42001e, other-fake'),
-    {
-      video: {type: 'avc1', details: '.42001e'},
-      unknown: ['other-fake']
-    },
+    [
+      {mediaType: 'video', type: 'avc1', details: '.42001e'},
+      {mediaType: 'unknown', type: 'other-fake', details: ''}
+    ],
     'parsed video and unknown'
   );
 });
@@ -203,10 +206,10 @@ QUnit.test('parses an unknown codec with a known video', function(assert) {
 QUnit.test('parses an unknown codec with a known text', function(assert) {
   assert.deepEqual(
     parseCodecs('stpp.ttml.im1t, other-fake'),
-    {
-      text: {type: 'stpp.ttml.im1t', details: ''},
-      unknown: ['other-fake']
-    },
+    [
+      {mediaType: 'text', type: 'stpp.ttml.im1t', details: ''},
+      {mediaType: 'unknown', type: 'other-fake', details: ''}
+    ],
     'parsed text and unknown'
   );
 });
@@ -214,13 +217,13 @@ QUnit.test('parses an unknown codec with a known text', function(assert) {
 QUnit.test('parses an unknown codec with a known audio/video/text', function(assert) {
   assert.deepEqual(
     parseCodecs('fake.codec, avc1.42001e, mp4a.40.2, stpp.ttml.im1t'),
-    {
-      audio: {type: 'mp4a', details: '.40.2'},
-      video: {type: 'avc1', details: '.42001e'},
-      text: {type: 'stpp.ttml.im1t', details: ''},
-      unknown: ['fake.codec']
-    },
-    'parsed faked video codec'
+    [
+      {mediaType: 'unknown', type: 'fake.codec', details: ''},
+      {mediaType: 'video', type: 'avc1', details: '.42001e'},
+      {mediaType: 'audio', type: 'mp4a', details: '.40.2'},
+      {mediaType: 'text', type: 'stpp.ttml.im1t', details: ''}
+    ],
+    'parsed video/audio/text and unknown codecs'
   );
 });
 
@@ -294,7 +297,7 @@ QUnit.test('returns falsey when no default for audio group', function(assert) {
   );
 });
 
-QUnit.test('returns audio profile for default in audio group', function(assert) {
+QUnit.test('returns parsed audio codecs for default in audio group', function(assert) {
   assert.deepEqual(
     codecsFromDefault(
       {
@@ -304,13 +307,13 @@ QUnit.test('returns audio profile for default in audio group', function(assert) 
               en: {
                 default: false,
                 playlists: [{
-                  attributes: { CODECS: 'mp4a.40.2' }
+                  attributes: { CODECS: 'mp4a.40.2, mp4a.40.20' }
                 }]
               },
               es: {
                 default: true,
                 playlists: [{
-                  attributes: { CODECS: 'mp4a.40.5' }
+                  attributes: { CODECS: 'mp4a.40.5, mp4a.40.7' }
                 }]
               }
             }
@@ -319,7 +322,10 @@ QUnit.test('returns audio profile for default in audio group', function(assert) 
       },
       'au1'
     ),
-    {audio: {type: 'mp4a', details: '.40.5'}},
+    [
+      {mediaType: 'audio', type: 'mp4a', details: '.40.5'},
+      {mediaType: 'audio', type: 'mp4a', details: '.40.7'}
+    ],
     'returned parsed codec audio profile'
   );
 });

--- a/test/codecs.test.js
+++ b/test/codecs.test.js
@@ -125,7 +125,7 @@ QUnit.module('parseCodecs');
 QUnit.test('parses text only codec string', function(assert) {
   assert.deepEqual(
     parseCodecs('stpp.ttml.im1t'),
-    [{mediaType: 'text', type: 'stpp.ttml.im1t', details: ''}],
+    {text: {type: 'stpp.ttml.im1t', details: ''}},
     'parsed text only codec string'
   );
 });
@@ -133,7 +133,7 @@ QUnit.test('parses text only codec string', function(assert) {
 QUnit.test('parses video only codec string', function(assert) {
   assert.deepEqual(
     parseCodecs('avc1.42001e'),
-    [{mediaType: 'video', type: 'avc1', details: '.42001e'}],
+    {video: {type: 'avc1', details: '.42001e'}},
     'parsed video only codec string'
   );
 });
@@ -141,7 +141,7 @@ QUnit.test('parses video only codec string', function(assert) {
 QUnit.test('parses audio only codec string', function(assert) {
   assert.deepEqual(
     parseCodecs('mp4a.40.2'),
-    [{mediaType: 'audio', type: 'mp4a', details: '.40.2'}],
+    {audio: {type: 'mp4a', details: '.40.2'}},
     'parsed audio only codec string'
   );
 });
@@ -149,11 +149,11 @@ QUnit.test('parses audio only codec string', function(assert) {
 QUnit.test('parses video, audio, and text codec string', function(assert) {
   assert.deepEqual(
     parseCodecs('avc1.42001e, mp4a.40.2, stpp.ttml.im1t'),
-    [
-      {mediaType: 'video', type: 'avc1', details: '.42001e'},
-      {mediaType: 'audio', type: 'mp4a', details: '.40.2'},
-      {mediaType: 'text', type: 'stpp.ttml.im1t', details: ''}
-    ],
+    {
+      video: {type: 'avc1', details: '.42001e'},
+      audio: {type: 'mp4a', details: '.40.2'},
+      text: {type: 'stpp.ttml.im1t', details: ''}
+    },
     'parsed video, audio, and text codec string'
   );
 });
@@ -161,11 +161,11 @@ QUnit.test('parses video, audio, and text codec string', function(assert) {
 QUnit.test('parses video, audio, and text codec with mixed case', function(assert) {
   assert.deepEqual(
     parseCodecs('AvC1.42001E, Mp4A.40.E, stpp.TTML.im1T'),
-    [
-      {mediaType: 'video', type: 'AvC1', details: '.42001E'},
-      {mediaType: 'audio', type: 'Mp4A', details: '.40.E'},
-      {mediaType: 'text', type: 'stpp.TTML.im1T', details: ''}
-    ],
+    {
+      video: {type: 'AvC1', details: '.42001E'},
+      audio: {type: 'Mp4A', details: '.40.E'},
+      text: {type: 'stpp.TTML.im1T', details: ''}
+    },
     'parsed video, audio, and text codec string'
   );
 });
@@ -173,10 +173,7 @@ QUnit.test('parses video, audio, and text codec with mixed case', function(asser
 QUnit.test('parses two unknown codec', function(assert) {
   assert.deepEqual(
     parseCodecs('fake.codec, other-fake'),
-    [
-      {mediaType: 'unknown', type: 'fake.codec', details: ''},
-      {mediaType: 'unknown', type: 'other-fake', details: ''}
-    ],
+    {unknown: ['fake.codec', 'other-fake']},
     'parsed faked codecs as video/audio'
   );
 });
@@ -184,21 +181,21 @@ QUnit.test('parses two unknown codec', function(assert) {
 QUnit.test('parses an unknown codec with a known audio', function(assert) {
   assert.deepEqual(
     parseCodecs('fake.codec, mp4a.40.2'),
-    [
-      {mediaType: 'unknown', type: 'fake.codec', details: ''},
-      {mediaType: 'audio', type: 'mp4a', details: '.40.2'}
-    ],
-    'parsed audio and unknwon'
+    {
+      audio: {type: 'mp4a', details: '.40.2'},
+      unknown: ['fake.codec']
+    },
+    'parsed faked video codec'
   );
 });
 
 QUnit.test('parses an unknown codec with a known video', function(assert) {
   assert.deepEqual(
     parseCodecs('avc1.42001e, other-fake'),
-    [
-      {mediaType: 'video', type: 'avc1', details: '.42001e'},
-      {mediaType: 'unknown', type: 'other-fake', details: ''}
-    ],
+    {
+      video: {type: 'avc1', details: '.42001e'},
+      unknown: ['other-fake']
+    },
     'parsed video and unknown'
   );
 });
@@ -206,10 +203,10 @@ QUnit.test('parses an unknown codec with a known video', function(assert) {
 QUnit.test('parses an unknown codec with a known text', function(assert) {
   assert.deepEqual(
     parseCodecs('stpp.ttml.im1t, other-fake'),
-    [
-      {mediaType: 'text', type: 'stpp.ttml.im1t', details: ''},
-      {mediaType: 'unknown', type: 'other-fake', details: ''}
-    ],
+    {
+      text: {type: 'stpp.ttml.im1t', details: ''},
+      unknown: ['other-fake']
+    },
     'parsed text and unknown'
   );
 });
@@ -217,13 +214,13 @@ QUnit.test('parses an unknown codec with a known text', function(assert) {
 QUnit.test('parses an unknown codec with a known audio/video/text', function(assert) {
   assert.deepEqual(
     parseCodecs('fake.codec, avc1.42001e, mp4a.40.2, stpp.ttml.im1t'),
-    [
-      {mediaType: 'unknown', type: 'fake.codec', details: ''},
-      {mediaType: 'video', type: 'avc1', details: '.42001e'},
-      {mediaType: 'audio', type: 'mp4a', details: '.40.2'},
-      {mediaType: 'text', type: 'stpp.ttml.im1t', details: ''}
-    ],
-    'parsed video/audio/text and unknown codecs'
+    {
+      audio: {type: 'mp4a', details: '.40.2'},
+      video: {type: 'avc1', details: '.42001e'},
+      text: {type: 'stpp.ttml.im1t', details: ''},
+      unknown: ['fake.codec']
+    },
+    'parsed faked video codec'
   );
 });
 
@@ -297,7 +294,7 @@ QUnit.test('returns falsey when no default for audio group', function(assert) {
   );
 });
 
-QUnit.test('returns parsed audio codecs for default in audio group', function(assert) {
+QUnit.test('returns audio profile for default in audio group', function(assert) {
   assert.deepEqual(
     codecsFromDefault(
       {
@@ -307,13 +304,13 @@ QUnit.test('returns parsed audio codecs for default in audio group', function(as
               en: {
                 default: false,
                 playlists: [{
-                  attributes: { CODECS: 'mp4a.40.2, mp4a.40.20' }
+                  attributes: { CODECS: 'mp4a.40.2' }
                 }]
               },
               es: {
                 default: true,
                 playlists: [{
-                  attributes: { CODECS: 'mp4a.40.5, mp4a.40.7' }
+                  attributes: { CODECS: 'mp4a.40.5' }
                 }]
               }
             }
@@ -322,10 +319,7 @@ QUnit.test('returns parsed audio codecs for default in audio group', function(as
       },
       'au1'
     ),
-    [
-      {mediaType: 'audio', type: 'mp4a', details: '.40.5'},
-      {mediaType: 'audio', type: 'mp4a', details: '.40.7'}
-    ],
+    {audio: {type: 'mp4a', details: '.40.5'}},
     'returned parsed codec audio profile'
   );
 });

--- a/test/codecs.test.js
+++ b/test/codecs.test.js
@@ -122,6 +122,14 @@ QUnit.test('translates legacy codecs', function(assert) {
 
 QUnit.module('parseCodecs');
 
+QUnit.test('parses text only codec string', function(assert) {
+  assert.deepEqual(
+    parseCodecs('stpp.ttml.im1t'),
+    {text: {type: 'stpp.ttml.im1t', details: ''}},
+    'parsed text only codec string'
+  );
+});
+
 QUnit.test('parses video only codec string', function(assert) {
   assert.deepEqual(
     parseCodecs('avc1.42001e'),
@@ -138,25 +146,81 @@ QUnit.test('parses audio only codec string', function(assert) {
   );
 });
 
-QUnit.test('parses video and audio codec string', function(assert) {
+QUnit.test('parses video, audio, and text codec string', function(assert) {
   assert.deepEqual(
-    parseCodecs('avc1.42001e, mp4a.40.2'),
+    parseCodecs('avc1.42001e, mp4a.40.2, stpp.ttml.im1t'),
     {
       video: {type: 'avc1', details: '.42001e'},
-      audio: {type: 'mp4a', details: '.40.2'}
+      audio: {type: 'mp4a', details: '.40.2'},
+      text: {type: 'stpp.ttml.im1t', details: ''}
     },
-    'parsed video and audio codec string'
+    'parsed video, audio, and text codec string'
   );
 });
 
-QUnit.test('parses video and audio codec with mixed case', function(assert) {
+QUnit.test('parses video, audio, and text codec with mixed case', function(assert) {
   assert.deepEqual(
-    parseCodecs('AvC1.42001E, Mp4A.40.E'),
+    parseCodecs('AvC1.42001E, Mp4A.40.E, stpp.TTML.im1T'),
     {
       video: {type: 'AvC1', details: '.42001E'},
-      audio: {type: 'Mp4A', details: '.40.E'}
+      audio: {type: 'Mp4A', details: '.40.E'},
+      text: {type: 'stpp.TTML.im1T', details: ''}
     },
-    'parsed video and audio codec string'
+    'parsed video, audio, and text codec string'
+  );
+});
+
+QUnit.test('parses two unknown codec', function(assert) {
+  assert.deepEqual(
+    parseCodecs('fake.codec, other-fake'),
+    {unknown: ['fake.codec', 'other-fake']},
+    'parsed faked codecs as video/audio'
+  );
+});
+
+QUnit.test('parses an unknown codec with a known audio', function(assert) {
+  assert.deepEqual(
+    parseCodecs('fake.codec, mp4a.40.2'),
+    {
+      audio: {type: 'mp4a', details: '.40.2'},
+      unknown: ['fake.codec']
+    },
+    'parsed faked video codec'
+  );
+});
+
+QUnit.test('parses an unknown codec with a known video', function(assert) {
+  assert.deepEqual(
+    parseCodecs('avc1.42001e, other-fake'),
+    {
+      video: {type: 'avc1', details: '.42001e'},
+      unknown: ['other-fake']
+    },
+    'parsed video and unknown'
+  );
+});
+
+QUnit.test('parses an unknown codec with a known text', function(assert) {
+  assert.deepEqual(
+    parseCodecs('stpp.ttml.im1t, other-fake'),
+    {
+      text: {type: 'stpp.ttml.im1t', details: ''},
+      unknown: ['other-fake']
+    },
+    'parsed text and unknown'
+  );
+});
+
+QUnit.test('parses an unknown codec with a known audio/video/text', function(assert) {
+  assert.deepEqual(
+    parseCodecs('fake.codec, avc1.42001e, mp4a.40.2, stpp.ttml.im1t'),
+    {
+      audio: {type: 'mp4a', details: '.40.2'},
+      video: {type: 'avc1', details: '.42001e'},
+      text: {type: 'stpp.ttml.im1t', details: ''},
+      unknown: ['fake.codec']
+    },
+    'parsed faked video codec'
   );
 });
 
@@ -395,4 +459,5 @@ QUnit.test('works as expected', function(assert) {
   assert.notOk(getMimeForCodec(), 'invalid codec returns undefined');
 
   assert.equal(getMimeForCodec('Mp4A.40.2,AvC1.42001E'), 'video/mp4;codecs="Mp4A.40.2,AvC1.42001E"', 'case is preserved');
+  assert.equal(getMimeForCodec('stpp.ttml.im1t'), 'application/mp4;codecs="stpp.ttml.im1t"', 'text is parsed');
 });


### PR DESCRIPTION
It recently came to our attention that there are text codecs out in the wild. While we do not currently support them we still need to be able to know that we don't support them by identifying them. This pull request adds back in some of the logic for unknown codecs and adds logic for text codecs.

~This is a BREAKING CHANGE, as previously we only supported 1 codec of each type.~ The breaking change has been moved to a new pull request see: https://github.com/videojs/vhs-utils/pull/23