### PR TITLE
feat: Parse any number of codecs

### DIFF
--- a/src/codecs.js
+++ b/src/codecs.js
@@ -98,8 +98,7 @@ export const mapLegacyAvcCodecs = function(codecString) {
  */
 export const parseCodecs = function(codecString = '') {
   const codecs = codecString.split(',');
-  const result = {};
-  const unknown = [];
+  const result = [];
 
   codecs.forEach(function(codec) {
     codec = codec.trim();
@@ -117,17 +116,13 @@ export const parseCodecs = function(codecString = '') {
       const type = codec.substring(0, match[1].length);
       const details = codec.replace(type, '');
 
-      result[name] = {type, details};
+      result.push({type, details, mediaType: name});
     });
 
     if (!codecType) {
-      unknown.push(codec);
+      result.push({type: codec, details: '', mediaType: 'unknown'});
     }
   });
-
-  if (unknown.length) {
-    result.unknown = unknown;
-  }
 
   return result;
 };

--- a/test/codecs.test.js
+++ b/test/codecs.test.js
@@ -125,7 +125,7 @@ QUnit.module('parseCodecs');
 QUnit.test('parses text only codec string', function(assert) {
   assert.deepEqual(
     parseCodecs('stpp.ttml.im1t'),
-    {text: {type: 'stpp.ttml.im1t', details: ''}},
+    [{mediaType: 'text', type: 'stpp.ttml.im1t', details: ''}],
     'parsed text only codec string'
   );
 });
@@ -133,7 +133,7 @@ QUnit.test('parses text only codec string', function(assert) {
 QUnit.test('parses video only codec string', function(assert) {
   assert.deepEqual(
     parseCodecs('avc1.42001e'),
-    {video: {type: 'avc1', details: '.42001e'}},
+    [{mediaType: 'video', type: 'avc1', details: '.42001e'}],
     'parsed video only codec string'
   );
 });
@@ -141,7 +141,7 @@ QUnit.test('parses video only codec string', function(assert) {
 QUnit.test('parses audio only codec string', function(assert) {
   assert.deepEqual(
     parseCodecs('mp4a.40.2'),
-    {audio: {type: 'mp4a', details: '.40.2'}},
+    [{mediaType: 'audio', type: 'mp4a', details: '.40.2'}],
     'parsed audio only codec string'
   );
 });
@@ -149,11 +149,11 @@ QUnit.test('parses audio only codec string', function(assert) {
 QUnit.test('parses video, audio, and text codec string', function(assert) {
   assert.deepEqual(
     parseCodecs('avc1.42001e, mp4a.40.2, stpp.ttml.im1t'),
-    {
-      video: {type: 'avc1', details: '.42001e'},
-      audio: {type: 'mp4a', details: '.40.2'},
-      text: {type: 'stpp.ttml.im1t', details: ''}
-    },
+    [
+      {mediaType: 'video', type: 'avc1', details: '.42001e'},
+      {mediaType: 'audio', type: 'mp4a', details: '.40.2'},
+      {mediaType: 'text', type: 'stpp.ttml.im1t', details: ''}
+    ],
     'parsed video, audio, and text codec string'
   );
 });
@@ -161,11 +161,11 @@ QUnit.test('parses video, audio, and text codec string', function(assert) {
 QUnit.test('parses video, audio, and text codec with mixed case', function(assert) {
   assert.deepEqual(
     parseCodecs('AvC1.42001E, Mp4A.40.E, stpp.TTML.im1T'),
-    {
-      video: {type: 'AvC1', details: '.42001E'},
-      audio: {type: 'Mp4A', details: '.40.E'},
-      text: {type: 'stpp.TTML.im1T', details: ''}
-    },
+    [
+      {mediaType: 'video', type: 'AvC1', details: '.42001E'},
+      {mediaType: 'audio', type: 'Mp4A', details: '.40.E'},
+      {mediaType: 'text', type: 'stpp.TTML.im1T', details: ''}
+    ],
     'parsed video, audio, and text codec string'
   );
 });
@@ -173,7 +173,10 @@ QUnit.test('parses video, audio, and text codec with mixed case', function(asser
 QUnit.test('parses two unknown codec', function(assert) {
   assert.deepEqual(
     parseCodecs('fake.codec, other-fake'),
-    {unknown: ['fake.codec', 'other-fake']},
+    [
+      {mediaType: 'unknown', type: 'fake.codec', details: ''},
+      {mediaType: 'unknown', type: 'other-fake', details: ''}
+    ],
     'parsed faked codecs as video/audio'
   );
 });
@@ -181,21 +184,21 @@ QUnit.test('parses two unknown codec', function(assert) {
 QUnit.test('parses an unknown codec with a known audio', function(assert) {
   assert.deepEqual(
     parseCodecs('fake.codec, mp4a.40.2'),
-    {
-      audio: {type: 'mp4a', details: '.40.2'},
-      unknown: ['fake.codec']
-    },
-    'parsed faked video codec'
+    [
+      {mediaType: 'unknown', type: 'fake.codec', details: ''},
+      {mediaType: 'audio', type: 'mp4a', details: '.40.2'}
+    ],
+    'parsed audio and unknwon'
   );
 });
 
 QUnit.test('parses an unknown codec with a known video', function(assert) {
   assert.deepEqual(
     parseCodecs('avc1.42001e, other-fake'),
-    {
-      video: {type: 'avc1', details: '.42001e'},
-      unknown: ['other-fake']
-    },
+    [
+      {mediaType: 'video', type: 'avc1', details: '.42001e'},
+      {mediaType: 'unknown', type: 'other-fake', details: ''}
+    ],
     'parsed video and unknown'
   );
 });
@@ -203,10 +206,10 @@ QUnit.test('parses an unknown codec with a known video', function(assert) {
 QUnit.test('parses an unknown codec with a known text', function(assert) {
   assert.deepEqual(
     parseCodecs('stpp.ttml.im1t, other-fake'),
-    {
-      text: {type: 'stpp.ttml.im1t', details: ''},
-      unknown: ['other-fake']
-    },
+    [
+      {mediaType: 'text', type: 'stpp.ttml.im1t', details: ''},
+      {mediaType: 'unknown', type: 'other-fake', details: ''}
+    ],
     'parsed text and unknown'
   );
 });
@@ -214,13 +217,13 @@ QUnit.test('parses an unknown codec with a known text', function(assert) {
 QUnit.test('parses an unknown codec with a known audio/video/text', function(assert) {
   assert.deepEqual(
     parseCodecs('fake.codec, avc1.42001e, mp4a.40.2, stpp.ttml.im1t'),
-    {
-      audio: {type: 'mp4a', details: '.40.2'},
-      video: {type: 'avc1', details: '.42001e'},
-      text: {type: 'stpp.ttml.im1t', details: ''},
-      unknown: ['fake.codec']
-    },
-    'parsed faked video codec'
+    [
+      {mediaType: 'unknown', type: 'fake.codec', details: ''},
+      {mediaType: 'video', type: 'avc1', details: '.42001e'},
+      {mediaType: 'audio', type: 'mp4a', details: '.40.2'},
+      {mediaType: 'text', type: 'stpp.ttml.im1t', details: ''}
+    ],
+    'parsed video/audio/text and unknown codecs'
   );
 });
 
@@ -294,7 +297,7 @@ QUnit.test('returns falsey when no default for audio group', function(assert) {
   );
 });
 
-QUnit.test('returns audio profile for default in audio group', function(assert) {
+QUnit.test('returns parsed audio codecs for default in audio group', function(assert) {
   assert.deepEqual(
     codecsFromDefault(
       {
@@ -304,13 +307,13 @@ QUnit.test('returns audio profile for default in audio group', function(assert) 
               en: {
                 default: false,
                 playlists: [{
-                  attributes: { CODECS: 'mp4a.40.2' }
+                  attributes: { CODECS: 'mp4a.40.2, mp4a.40.20' }
                 }]
               },
               es: {
                 default: true,
                 playlists: [{
-                  attributes: { CODECS: 'mp4a.40.5' }
+                  attributes: { CODECS: 'mp4a.40.5, mp4a.40.7' }
                 }]
               }
             }
@@ -319,7 +322,10 @@ QUnit.test('returns audio profile for default in audio group', function(assert) 
       },
       'au1'
     ),
-    {audio: {type: 'mp4a', details: '.40.5'}},
+    [
+      {mediaType: 'audio', type: 'mp4a', details: '.40.5'},
+      {mediaType: 'audio', type: 'mp4a', details: '.40.7'}
+    ],
     'returned parsed codec audio profile'
   );
 });


### PR DESCRIPTION
BREAKING CHANGE: parseCodecs now returns an array of codecs that were
parsed.