### PR TITLE
perf: use native URL when available

### DIFF
--- a/src/resolve-url.js
+++ b/src/resolve-url.js
@@ -7,14 +7,18 @@ const resolveUrl = (baseUrl, relativeUrl) => {
     return relativeUrl;
   }
 
+  // IE11 supports URL but not the URL constructor
+  // feature detect the behavior we want
+  const nativeURL = typeof window.URL === 'function';
+
   // if the base URL is relative then combine with the current location
-  if (window.URL) {
+  if (nativeURL) {
     baseUrl = new window.URL(baseUrl, window.location);
   } else if (!(/\/\//i).test(baseUrl)) {
     baseUrl = URLToolkit.buildAbsoluteURL(window.location && window.location.href || '', baseUrl);
   }
 
-  if (window.URL) {
+  if (nativeURL) {
     return new URL(relativeUrl, baseUrl).href;
   }
   return URLToolkit.buildAbsoluteURL(baseUrl, relativeUrl);

--- a/src/resolve-url.js
+++ b/src/resolve-url.js
@@ -9,10 +9,18 @@ const resolveUrl = (baseUrl, relativeUrl) => {
 
   // if the base URL is relative then combine with the current location
   if (!(/\/\//i).test(baseUrl)) {
-    baseUrl = URLToolkit.buildAbsoluteURL(window.location && window.location.href || '', baseUrl);
+    if (window.URL) {
+      baseUrl = new window.URL(baseUrl, window.location);
+    } else {
+      baseUrl = URLToolkit.buildAbsoluteURL(window.location && window.location.href || '', baseUrl);
+    }
   }
 
+  if (window.URL) {
+    return new URL(relativeUrl, baseUrl).href;
+  }
   return URLToolkit.buildAbsoluteURL(baseUrl, relativeUrl);
+
 };
 
 export default resolveUrl;

--- a/src/resolve-url.js
+++ b/src/resolve-url.js
@@ -8,12 +8,10 @@ const resolveUrl = (baseUrl, relativeUrl) => {
   }
 
   // if the base URL is relative then combine with the current location
-  if (!(/\/\//i).test(baseUrl)) {
-    if (window.URL) {
-      baseUrl = new window.URL(baseUrl, window.location);
-    } else {
-      baseUrl = URLToolkit.buildAbsoluteURL(window.location && window.location.href || '', baseUrl);
-    }
+  if (window.URL) {
+    baseUrl = new window.URL(baseUrl, window.location);
+  } else if (!(/\/\//i).test(baseUrl)) {
+    baseUrl = URLToolkit.buildAbsoluteURL(window.location && window.location.href || '', baseUrl);
   }
 
   if (window.URL) {

--- a/src/resolve-url.js
+++ b/src/resolve-url.js
@@ -11,6 +11,8 @@ const resolveUrl = (baseUrl, relativeUrl) => {
   // feature detect the behavior we want
   const nativeURL = typeof window.URL === 'function';
 
+  const protocolLess = !(/^https?:/.test(baseUrl));
+
   // if the base URL is relative then combine with the current location
   if (nativeURL) {
     baseUrl = new window.URL(baseUrl, window.location);
@@ -19,7 +21,14 @@ const resolveUrl = (baseUrl, relativeUrl) => {
   }
 
   if (nativeURL) {
-    return new URL(relativeUrl, baseUrl).href;
+    const newUrl = new URL(relativeUrl, baseUrl);
+
+    // if we're a protocol-less url, return a protocol-less url
+    if (protocolLess) {
+      return newUrl.href.slice(newUrl.protocol.length);
+    }
+
+    return newUrl;
   }
   return URLToolkit.buildAbsoluteURL(baseUrl, relativeUrl);
 

--- a/src/resolve-url.js
+++ b/src/resolve-url.js
@@ -1,6 +1,8 @@
 import URLToolkit from 'url-toolkit';
 import window from 'global/window';
 
+const DEFAULT_LOCATION = 'http://example.com';
+
 const resolveUrl = (baseUrl, relativeUrl) => {
   // return early if we don't need to resolve
   if ((/^[a-z]+:/i).test(relativeUrl)) {
@@ -18,7 +20,7 @@ const resolveUrl = (baseUrl, relativeUrl) => {
 
   // if the base URL is relative then combine with the current location
   if (nativeURL) {
-    baseUrl = new window.URL(baseUrl, window.location || 'http://example.com');
+    baseUrl = new window.URL(baseUrl, window.location || DEFAULT_LOCATION);
   } else if (!(/\/\//i).test(baseUrl)) {
     baseUrl = URLToolkit.buildAbsoluteURL(window.location && window.location.href || '', baseUrl);
   }
@@ -30,7 +32,7 @@ const resolveUrl = (baseUrl, relativeUrl) => {
     // and if we're location-less, remove the location
     // otherwise, return the url unmodified
     if (removeLocation) {
-      return newUrl.href.slice(18);
+      return newUrl.href.slice(DEFAULT_LOCATION.length);
     } else if (protocolLess) {
       return newUrl.href.slice(newUrl.protocol.length);
     }

--- a/test/resolve-url.test.js
+++ b/test/resolve-url.test.js
@@ -28,6 +28,8 @@ QUnit.test('works with a selection of valid urls', function(assert) {
     resolveUrl('/a/b/cd/e.m3u8', 'https://example.com:8080/z.ts'),
     'https://example.com:8080/z.ts'
   );
-  assert.equal(resolveUrl('/a/b/cd/e.m3u8', 'z.ts'), currentLocation + '/a/b/cd/z.ts');
-  assert.equal(resolveUrl('/a/b/cd/e.m3u8', '../../../z.ts'), currentLocation + '/z.ts');
+  if (!window.location) {
+    assert.equal(resolveUrl('/a/b/cd/e.m3u8', 'z.ts'), currentLocation + '/a/b/cd/z.ts');
+    assert.equal(resolveUrl('/a/b/cd/e.m3u8', '../../../z.ts'), currentLocation + '/z.ts');
+  }
 });

--- a/test/resolve-url.test.js
+++ b/test/resolve-url.test.js
@@ -18,12 +18,7 @@ QUnit.test('works with a selection of valid urls', function(assert) {
     'https://example.com/z.ts'
   );
   assert.equal(resolveUrl('http://a.com/b/cd/e.m3u8', 'z.ts'), 'http://a.com/b/cd/z.ts');
-  // window.URL cannot return protocol-less (what they call schema-relative) URLs
-  if (typeof window.URL === 'function') {
-    assert.equal(resolveUrl('//a.com/b/cd/e.m3u8', 'z.ts'), 'http://a.com/b/cd/z.ts');
-  } else {
-    assert.equal(resolveUrl('//a.com/b/cd/e.m3u8', 'z.ts'), '//a.com/b/cd/z.ts');
-  }
+  assert.equal(resolveUrl('//a.com/b/cd/e.m3u8', 'z.ts'), '//a.com/b/cd/z.ts');
   assert.equal(
     resolveUrl('/a/b/cd/e.m3u8', 'https://example.com:8080/z.ts'),
     'https://example.com:8080/z.ts'

--- a/test/resolve-url.test.js
+++ b/test/resolve-url.test.js
@@ -19,7 +19,11 @@ QUnit.test('works with a selection of valid urls', function(assert) {
   );
   assert.equal(resolveUrl('http://a.com/b/cd/e.m3u8', 'z.ts'), 'http://a.com/b/cd/z.ts');
   // window.URL cannot return protocol-less (what they call schema-relative) URLs
-  assert.equal(resolveUrl('//a.com/b/cd/e.m3u8', 'z.ts'), 'http://a.com/b/cd/z.ts');
+  if (typeof window.URL === 'function') {
+    assert.equal(resolveUrl('//a.com/b/cd/e.m3u8', 'z.ts'), 'http://a.com/b/cd/z.ts');
+  } else {
+    assert.equal(resolveUrl('//a.com/b/cd/e.m3u8', 'z.ts'), '//a.com/b/cd/z.ts');
+  }
   assert.equal(
     resolveUrl('/a/b/cd/e.m3u8', 'https://example.com:8080/z.ts'),
     'https://example.com:8080/z.ts'

--- a/test/resolve-url.test.js
+++ b/test/resolve-url.test.js
@@ -18,7 +18,8 @@ QUnit.test('works with a selection of valid urls', function(assert) {
     'https://example.com/z.ts'
   );
   assert.equal(resolveUrl('http://a.com/b/cd/e.m3u8', 'z.ts'), 'http://a.com/b/cd/z.ts');
-  assert.equal(resolveUrl('//a.com/b/cd/e.m3u8', 'z.ts'), '//a.com/b/cd/z.ts');
+  // window.URL cannot return protocol-less (what they call schema-relative) URLs
+  assert.equal(resolveUrl('//a.com/b/cd/e.m3u8', 'z.ts'), 'http://a.com/b/cd/z.ts');
   assert.equal(
     resolveUrl('/a/b/cd/e.m3u8', 'https://example.com:8080/z.ts'),
     'https://example.com:8080/z.ts'

--- a/test/resolve-url.test.js
+++ b/test/resolve-url.test.js
@@ -23,8 +23,6 @@ QUnit.test('works with a selection of valid urls', function(assert) {
     resolveUrl('/a/b/cd/e.m3u8', 'https://example.com:8080/z.ts'),
     'https://example.com:8080/z.ts'
   );
-  if (!window.location) {
-    assert.equal(resolveUrl('/a/b/cd/e.m3u8', 'z.ts'), currentLocation + '/a/b/cd/z.ts');
-    assert.equal(resolveUrl('/a/b/cd/e.m3u8', '../../../z.ts'), currentLocation + '/z.ts');
-  }
+  assert.equal(resolveUrl('/a/b/cd/e.m3u8', 'z.ts'), currentLocation + '/a/b/cd/z.ts');
+  assert.equal(resolveUrl('/a/b/cd/e.m3u8', '../../../z.ts'), currentLocation + '/z.ts');
 });


### PR DESCRIPTION
@gesinger did a quick profile and usage when from ~30% to ~3% of time spent doing work.

This is now fully backwards compatible across all platforms.