### PR TITLE
fix: properly handle data URIs

### DIFF
--- a/src/resolve-url.js
+++ b/src/resolve-url.js
@@ -11,7 +11,7 @@ const resolveUrl = (baseUrl, relativeUrl) => {
 
   // if baseUrl is a data URI, ignore it and resolve everything relative to window.location
   if ((/^data:/).test(baseUrl)) {
-    baseUrl = window.location.href;
+    baseUrl = window.location && window.location.href;
   }
 
   // IE11 supports URL but not the URL constructor

--- a/src/resolve-url.js
+++ b/src/resolve-url.js
@@ -11,7 +11,7 @@ const resolveUrl = (baseUrl, relativeUrl) => {
 
   // if baseUrl is a data URI, ignore it and resolve everything relative to window.location
   if ((/^data:/).test(baseUrl)) {
-    baseUrl = window.location;
+    baseUrl = window.location.href;
   }
 
   // IE11 supports URL but not the URL constructor

--- a/src/resolve-url.js
+++ b/src/resolve-url.js
@@ -9,6 +9,11 @@ const resolveUrl = (baseUrl, relativeUrl) => {
     return relativeUrl;
   }
 
+  // if baseUrl is a data URI, ignore it and resolve everything relative to window.location
+  if ((/^data:/).test(baseUrl)) {
+    baseUrl = window.location;
+  }
+
   // IE11 supports URL but not the URL constructor
   // feature detect the behavior we want
   const nativeURL = typeof window.URL === 'function';

--- a/src/resolve-url.js
+++ b/src/resolve-url.js
@@ -11,7 +11,7 @@ const resolveUrl = (baseUrl, relativeUrl) => {
 
   // if baseUrl is a data URI, ignore it and resolve everything relative to window.location
   if ((/^data:/).test(baseUrl)) {
-    baseUrl = window.location && window.location.href;
+    baseUrl = window.location && window.location.href || '';
   }
 
   // IE11 supports URL but not the URL constructor

--- a/test/resolve-url.test.js
+++ b/test/resolve-url.test.js
@@ -40,4 +40,10 @@ QUnit.test('works with a selection of valid urls', function(assert) {
     'http://example.com/hello.m3u8',
     'absolute urls should still be absolute even with a data uri'
   );
+
+  assert.equal(
+    resolveUrl('http://example.com', 'data:application/dash+xml;charset=utf-8,http%3A%2F%2Fexample.com'),
+    'data:application/dash+xml;charset=utf-8,http%3A%2F%2Fexample.com',
+    'data uri is treated as an absolute url'
+  );
 });

--- a/test/resolve-url.test.js
+++ b/test/resolve-url.test.js
@@ -8,9 +8,11 @@ QUnit.module('URL resolver');
 
 QUnit.test('works with a selection of valid urls', function(assert) {
   let currentLocation = '';
+  let currentPath = '';
 
   if (window.location && window.location.protocol) {
     currentLocation = window.location.protocol + '//' + window.location.host;
+    currentPath = window.location.pathname.split('/').slice(0, -1).join('/');
   }
 
   assert.equal(
@@ -25,4 +27,17 @@ QUnit.test('works with a selection of valid urls', function(assert) {
   );
   assert.equal(resolveUrl('/a/b/cd/e.m3u8', 'z.ts'), currentLocation + '/a/b/cd/z.ts');
   assert.equal(resolveUrl('/a/b/cd/e.m3u8', '../../../z.ts'), currentLocation + '/z.ts');
+
+  assert.equal(
+    resolveUrl('data:application/dash+xml;charset=utf-8,http%3A%2F%2Fexample.com', 'hello.m3u8'),
+    // we need to add the currentPath because we're actually working relative to window.location
+    currentLocation + currentPath + '/hello.m3u8',
+    'resolves urls relative to window when given a data base url'
+  );
+
+  assert.equal(
+    resolveUrl('data:application/dash+xml;charset=utf-8,http%3A%2F%2Fexample.com', 'http://example.com/hello.m3u8'),
+    'http://example.com/hello.m3u8',
+    'absolute urls should still be absolute even with a data uri'
+  );
 });


### PR DESCRIPTION
There are the following two cases:
- a data URI is provided for the baseURL
  - in this case, ignore the data URI and resolve against `window.location` or a default location
- a data URI is provided for the relativeURL
  - in this case, return the data URI as it should be treated as an absolute URL

Fixes videojs/video.js#7240