### PR TITLE
chore: do not run es-check on publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "watch:js": "npm run build:js -- -w",
     "watch:cjs": "npm run build:cjs -- -w",
     "watch:es": "npm run build:es -- -w",
-    "prepublishOnly": "npm-run-all build-prod && vjsverify --verbose"
+    "prepublishOnly": "npm-run-all build-prod && vjsverify --verbose --skip-es-check"
   },
   "engines": {
     "node": ">=8",


### PR DESCRIPTION
Since the code is no longer transpiled down to ES5, we don't need this (and, in fact, it would prevent publishing).