### PR TITLE
feat: Add check for ManagedMediaSource support

### DIFF
--- a/src/codecs.js
+++ b/src/codecs.js
@@ -202,9 +202,26 @@ export const getMimeForCodec = (codecString) => {
   return `${type}/${container};codecs="${codecString}"`;
 };
 
-export const browserSupportsCodec = (codecString = '') => window.MediaSource &&
+/**
+ * Tests whether the codec is supported by MediaSource. Optionally also tests ManagedMediaSource.
+ *
+ * @param {string} codecString
+ *        Codec to test
+ * @param {boolean} [withMMS]
+ *        Whether to check if ManagedMediaSource supports it
+ * @return {boolean}
+ *          Codec is supported
+ */
+export const browserSupportsCodec = (codecString = '', withMMS = false) => (
+  window.MediaSource &&
   window.MediaSource.isTypeSupported &&
-  window.MediaSource.isTypeSupported(getMimeForCodec(codecString)) || false;
+  window.MediaSource.isTypeSupported(getMimeForCodec(codecString))
+) || (
+  withMMS &&
+  window.ManagedMediaSource &&
+  window.ManagedMediaSource.isTypeSupported &&
+  window.ManagedMediaSource.isTypeSupported(getMimeForCodec(codecString))
+) || false;
 
 export const muxerSupportsCodec = (codecString = '') => codecString.toLowerCase().split(',').every((codec) => {
   codec = codec.trim();

--- a/test/codecs.test.js
+++ b/test/codecs.test.js
@@ -422,9 +422,11 @@ QUnit.test('works as expected', function(assert) {
 QUnit.module('browserSupportsCodec', {
   beforeEach() {
     this.oldMediaSource = window.MediaSource;
+    this.oldManagedMediaSource = window.ManagedMediaSource;
   },
   afterEach() {
     window.MediaSource = this.oldMediaSource;
+    window.ManagedMediaSource = this.oldManagedMediaSource;
   }
 });
 
@@ -440,6 +442,47 @@ QUnit.test('works as expected', function(assert) {
 
   window.MediaSource = {isTypeSupported: null};
   assert.notOk(browserSupportsCodec('test'), 'no isTypeSupported, browser does not support codec');
+});
+
+QUnit.test('works as expected when ManagedMediaSource supported but checks not requested', function(assert) {
+  window.MediaSource = {isTypeSupported: () => false};
+  window.ManagedMediaSource = {isTypeSupported: () => true};
+  assert.notOk(browserSupportsCodec('test'), 'isTypeSupported false, browser does not support codec, ManangedMediaSource would support, but not requested');
+
+  window.MediaSource = null;
+  window.ManagedMediaSource = {isTypeSupported: () => true};
+  assert.notOk(browserSupportsCodec('test'), 'no MediaSource, browser does not support codec, ManangedMediaSource would support, but not requested');
+
+  window.MediaSource = {isTypeSupported: null};
+  window.ManagedMediaSource = {isTypeSupported: () => true};
+  assert.notOk(browserSupportsCodec('test'), 'no isTypeSupported, browser does not support codec, ManangedMediaSource would support, but not requested');
+});
+
+QUnit.test('works as expected with ManagedMediaSource checks', function(assert) {
+  window.MediaSource = {isTypeSupported: () => false};
+  window.ManagedMediaSource = {isTypeSupported: () => true};
+  assert.ok(browserSupportsCodec('test', true), 'isTypeSupported true, MediaSource does not support codec, but ManangedMediaSource does and was requested');
+
+  window.MediaSource = null;
+  window.ManagedMediaSource = {isTypeSupported: () => true};
+  assert.ok(browserSupportsCodec('test', true), 'isTypeSupported true, no MediaSource, but ManangedMediaSource supports codec and was requested');
+
+  window.MediaSource = {isTypeSupported: null};
+  window.ManagedMediaSource = {isTypeSupported: () => true};
+  assert.ok(browserSupportsCodec('test', true), 'isTypeSupported true, no isTypeSupported on MediaSource, but ManangedMediaSource supports and was requested');
+
+  window.MediaSource = null;
+  window.ManagedMediaSource = {isTypeSupported: () => false};
+  assert.notOk(browserSupportsCodec('test', true), 'isTypeSupported false, no MediaSource and ManagedMediaSource does not support codec');
+
+  window.MediaSource = null;
+  window.ManagedMediaSource = null;
+  assert.notOk(browserSupportsCodec('test', true), 'no MediaSource nor ManagedMediaSource');
+
+  window.MediaSource = null;
+  window.MediaSource = {isTypeSupported: null};
+  assert.notOk(browserSupportsCodec('test', true), 'no isTypeSupported on ManagaedMediaSource, browser does not support codec');
+
 });
 
 QUnit.module('getMimeForCodec');


### PR DESCRIPTION
Adds, optionally, a check for codec support by `ManagedMediaSource` in `browserSupportsCodec()`.

VHS will not register itself as a source handler unless this returns true. Currently this is a test against `MediaSource` only. The new optional check allows this to work on new iOS on iPhones, which supports `ManagedMediaSource` but not `MediaSource`. The check is optional so that VHS would be able to choose whether to check for support, so playback with `ManagedMediaSource` can be made optional there, and this also retains backwards compatibility.