### PR TITLE
refactor: remove url-toolkit dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9531,11 +9531,6 @@
       "dev": true,
       "optional": true
     },
-    "url-toolkit": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/url-toolkit/-/url-toolkit-2.2.1.tgz",
-      "integrity": "sha512-8+DzgrtDZYZGhHaAop5WGVghMdCfOLGbhcArsJD0qDll71FXa7EeKxi2hilPIscn2nwMz4PRjML32Sz4JTN0Xw=="
-    },
     "use": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -76,8 +76,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.12.5",
-    "global": "^4.4.0",
-    "url-toolkit": "^2.2.1"
+    "global": "^4.4.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.12.8",

--- a/src/resolve-url.js
+++ b/src/resolve-url.js
@@ -1,6 +1,6 @@
 import window from 'global/window';
 
-const DEFAULT_LOCATION = 'http://example.com';
+const DEFAULT_LOCATION = 'https://example.com';
 
 const resolveUrl = (baseUrl, relativeUrl) => {
   // return early if we don't need to resolve

--- a/src/resolve-url.js
+++ b/src/resolve-url.js
@@ -1,4 +1,3 @@
-import URLToolkit from 'url-toolkit';
 import window from 'global/window';
 
 const DEFAULT_LOCATION = 'http://example.com';
@@ -14,37 +13,26 @@ const resolveUrl = (baseUrl, relativeUrl) => {
     baseUrl = window.location && window.location.href || '';
   }
 
-  // IE11 supports URL but not the URL constructor
-  // feature detect the behavior we want
-  const nativeURL = typeof window.URL === 'function';
-
   const protocolLess = (/^\/\//.test(baseUrl));
   // remove location if window.location isn't available (i.e. we're in node)
   // and if baseUrl isn't an absolute url
   const removeLocation = !window.location && !(/\/\//i).test(baseUrl);
 
   // if the base URL is relative then combine with the current location
-  if (nativeURL) {
-    baseUrl = new window.URL(baseUrl, window.location || DEFAULT_LOCATION);
-  } else if (!(/\/\//i).test(baseUrl)) {
-    baseUrl = URLToolkit.buildAbsoluteURL(window.location && window.location.href || '', baseUrl);
+  baseUrl = new window.URL(baseUrl, window.location || DEFAULT_LOCATION);
+
+  const newUrl = new URL(relativeUrl, baseUrl);
+
+  // if we're a protocol-less url, remove the protocol
+  // and if we're location-less, remove the location
+  // otherwise, return the url unmodified
+  if (removeLocation) {
+    return newUrl.href.slice(DEFAULT_LOCATION.length);
+  } else if (protocolLess) {
+    return newUrl.href.slice(newUrl.protocol.length);
   }
 
-  if (nativeURL) {
-    const newUrl = new URL(relativeUrl, baseUrl);
-
-    // if we're a protocol-less url, remove the protocol
-    // and if we're location-less, remove the location
-    // otherwise, return the url unmodified
-    if (removeLocation) {
-      return newUrl.href.slice(DEFAULT_LOCATION.length);
-    } else if (protocolLess) {
-      return newUrl.href.slice(newUrl.protocol.length);
-    }
-
-    return newUrl.href;
-  }
-  return URLToolkit.buildAbsoluteURL(baseUrl, relativeUrl);
+  return newUrl.href;
 
 };
 


### PR DESCRIPTION
- Removes url-toolkit as URL is available on supported browsers.
- Changes the default URL to HTTPS. Fixes #39 