### PR TITLE
chore: Update CI actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
       should-skip-job: ${{steps.skip-check.outputs.should_skip}}
     steps:
       - id: skip-check
-        uses: fkirc/skip-duplicate-actions@v2.1.0
+        uses: fkirc/skip-duplicate-actions@v5
         with:
           github_token: ${{github.token}}
 
@@ -29,11 +29,14 @@ jobs:
       CI_TEST_TYPE: ${{matrix.test-type}}
     runs-on: ${{matrix.os}}
     steps:
+    - name: Disable apparmor, which breaks chromium headless
+      run: sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+
     - name: checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v5
 
     - name: read node version from .nvmrc
-      run: echo ::set-output name=NVMRC::$(cat .nvmrc)
+      run: echo "NVMRC=$(cat .nvmrc)" >> $GITHUB_OUTPUT
       shell: bash
       id: nvm
 
@@ -47,7 +50,7 @@ jobs:
       run: pulseaudio -D
 
     - name: setup node
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v6
       with:
         node-version: '${{steps.nvm.outputs.NVMRC}}'
         cache: npm
@@ -66,7 +69,7 @@ jobs:
         run: npm run test
 
     - name: coverage
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v5
       with:
         token: ${{secrets.CODECOV_TOKEN}}
         files: './test/dist/coverage/coverage-final.json'


### PR DESCRIPTION
- Bump actions to supported versions
- Replace deprecated set-output
- Disable app armor, as it breaks Chromium Headless